### PR TITLE
Pull doc

### DIFF
--- a/.github/workflows/build-page.yml
+++ b/.github/workflows/build-page.yml
@@ -28,49 +28,9 @@ jobs:
         name: Setup Yarn
       - run: make build_deploy
         name: Build Jekyll site
-#       - uses: actions/cache@v2
-#         name: Restore dependent gems
-#         with:
-#           path: vendor/bundle
-#           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-#           restore-keys: |
-#             ${{ runner.os }}-gems-
-#       - uses: limjh16/jekyll-action-ts@v2
-#         name: Build Jekyll
-#         with:
-#           build_only: true
-#           # remove in the future if this action picks up the page branch name correctly
-#           target_branch: gh-pages
-#           #  default build_dir is /github/jekyll_build; /github/workspace is the mount point for pyose.github.io
-#           target_path: ../workspace/build
-#       - uses: actions/checkout@v3
-#         name: Checkout previously built docs
-#         with: 
-#           ref: gh-pages
-#           path: gh-pages-old
-#       - name: Purge old site and assemble new
-#         run: |
-#           mv gh-pages-old/docs gh-pages-docs
-#           rm -r gh-pages-old
-#           mkdir gh-pages
-#           mv gh-pages-docs gh-pages/docs
-#           # no write permission to ./build outside container, has to make a copy
-#           cp -r build/* gh-pages
-#       - name: Download built documentation
-#         if: ${{ github.event.action == 'circle-ci-build' }}
-#         run: |
-#           export CIRCLE_TOKEN=?circle-token=${{ secrets.CIRCLECI }}
-#           export ARTIFACTS=$(curl -sS https://circleci.com/api/v1.1/project/github/pypose/pypose/${{ github.event.client_payload.job_num }}/artifacts$CIRCLE_TOKEN)
-#           wget -q -O sphinx-docs.tar.gz $(echo $ARTIFACTS | grep -o 'https://[^"]*')$CIRCLE_TOKEN
-#           mkdir sphinx-docs && tar -xf sphinx-docs.tar.gz -C sphinx-docs
-#           # move to docs/pr/<pr number> if is from pr
-#           PR_NUM="${{ github.event.client_payload.pr_num }}"
-#           [[ ! -z "$PR_NUM" ]] && DEST_SUFFIX="preview/pr/$PR_NUM" || DEST_SUFFIX=""
-#           mkdir -p gh-pages/docs/$DEST_SUFFIX
-#           rsync -a sphinx-docs/build/dirhtml/ gh-pages/docs/$DEST_SUFFIX --delete --exclude preview
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:
-          token: ${{ secrets.JEKYLL_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           folder: _site

--- a/.github/workflows/build-page.yml
+++ b/.github/workflows/build-page.yml
@@ -7,8 +7,6 @@ on:
     branches: [ master ]
 #   schedule:
 #     - cron: '30 1 * * *'
-  repository_dispatch:
-    types: [circle-ci-build]
 
 jobs:
   build-jekyll:

--- a/.github/workflows/pull-doc.yml
+++ b/.github/workflows/pull-doc.yml
@@ -1,0 +1,39 @@
+name: pull-doc-from-circleci
+
+on:
+  repository_dispatch:
+    types: [circle-ci-build]
+
+jobs:
+  pull-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout pypose/pypose.github.io
+        with:
+          path: 'repo'
+          fetch-depth: 0 # per instruction of https://github.com/marketplace/actions/github-push
+          persist-credentials: true
+      - name: Download built documentation
+        run: |
+          export CIRCLE_TOKEN=?circle-token=${{ secrets.CIRCLECI }}
+          export ARTIFACTS=$(curl -sS https://circleci.com/api/v1.1/project/github/pypose/pypose/${{ github.event.client_payload.job_num }}/artifacts$CIRCLE_TOKEN)
+          wget -q -O sphinx-docs.tar.gz $(echo $ARTIFACTS | grep -o 'https://[^"]*')$CIRCLE_TOKEN
+          mkdir sphinx-docs && tar -xf sphinx-docs.tar.gz -C sphinx-docs
+          # move to docs/pr/<pr number> if is from pr
+          PR_NUM="${{ github.event.client_payload.pr_num }}"
+          [[ ! -z "$PR_NUM" ]] && DEST_SUFFIX="preview/pr/$PR_NUM" || DEST_SUFFIX="master"
+          mkdir -p docs/$DEST_SUFFIX
+          rsync -a sphinx-docs/build/dirhtml/ repo/docs/$DEST_SUFFIX --delete --exclude preview
+      - name: Commit files
+        run: |
+          cd repo
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add docs
+          git commit -m "Add docs from pypose/pypose"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          directory: repo
+          branch: test-pull-doc

--- a/.github/workflows/pull-doc.yml
+++ b/.github/workflows/pull-doc.yml
@@ -23,7 +23,7 @@ jobs:
           # move to docs/pr/<pr number> if is from pr
           PR_NUM="${{ github.event.client_payload.pr_num }}"
           [[ ! -z "$PR_NUM" ]] && DEST_SUFFIX="preview/pr/$PR_NUM" || DEST_SUFFIX="master"
-          mkdir -p docs/$DEST_SUFFIX
+          mkdir -p repo/docs/$DEST_SUFFIX
           rsync -a sphinx-docs/build/dirhtml/ repo/docs/$DEST_SUFFIX --delete --exclude preview
       - name: Commit files
         run: |

--- a/.github/workflows/pull-doc.yml
+++ b/.github/workflows/pull-doc.yml
@@ -36,4 +36,4 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           directory: repo
-          branch: test-pull-doc
+          branch: master


### PR DESCRIPTION
Finalize action for automatic doc integration. `pull-doc-from-circleci` action will be in place of the old `build-page-with-doc` action, triggered by [CircleCI builds](https://github.com/pypose/pypose/blob/8b1a12f18485413af9a845fe354be6fd40f31897/.circleci/config.yml#L126-L136) to download and assemble sphinx docs (the new action only downloads relevant docs and push to the master branch. The push action will trigger a page build).